### PR TITLE
Added support for HKClinicalRecord.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.0] - 08.01.2024.
+
+* Added support for HKClinicalRecord
+
 ## [3.0.0] - 12.03.2023.
 
 * Check for Health data availability

--- a/Example/HealthKitReporter.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/HealthKitReporter.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		70ED962EB2E153C9FF71449F183EB92C /* Extensions+HKCategoryValueHeadphoneAudioExposureEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F7E69DFF38A7DCAD305271E21E7B66 /* Extensions+HKCategoryValueHeadphoneAudioExposureEvent.swift */; };
 		72E09764C778579D86111A27DC1C24B3 /* Device.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D69270819100EAB8BDBF1A42474EDED /* Device.swift */; };
 		73548876675C72560DA62B3A054517EE /* Extensions+HKCategoryValueOvulationTestResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD4232F0A2B118D033985000AD5D0CB /* Extensions+HKCategoryValueOvulationTestResult.swift */; };
+		7354B0B72C6293B4005297E1 /* ClinicalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7354B0B62C6293B4005297E1 /* ClinicalType.swift */; };
+		7354B0BA2C629433005297E1 /* Extensions+HKClinicalRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7354B0B82C629433005297E1 /* Extensions+HKClinicalRecord.swift */; };
+		7354B0BD2C62945F005297E1 /* ClinicalRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7354B0BC2C62945F005297E1 /* ClinicalRecord.swift */; };
 		7777396AD7F76C1FFA915EDB8D68FDD7 /* Extensions+HKCategoryValueCervicalMucusQuality.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA77ED0476C73CBFC08F47BF12D6D1E9 /* Extensions+HKCategoryValueCervicalMucusQuality.swift */; };
 		7835AED4290DA39000D9CB35 /* Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7835AED3290DA39000D9CB35 /* Metadata.swift */; };
 		79023528495E32B002B9378AF8B238C4 /* CorrelationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17B2FDE0B6D0320BE2EB63FF8E7C28C /* CorrelationType.swift */; };
@@ -203,6 +206,9 @@
 		71D8BEAF4ADFF6BB7D99C7D261B03A10 /* Pods-HealthKitReporter_Tests */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = "Pods-HealthKitReporter_Tests"; path = Pods_HealthKitReporter_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		725EEB8C2CE54A8A15BDD5F3DB916AB3 /* Extensions+Date.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Extensions+Date.swift"; sourceTree = "<group>"; };
 		73010CC983E3809BECEE5348DA1BB8C6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		7354B0B62C6293B4005297E1 /* ClinicalType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClinicalType.swift; sourceTree = "<group>"; };
+		7354B0B82C629433005297E1 /* Extensions+HKClinicalRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Extensions+HKClinicalRecord.swift"; sourceTree = "<group>"; };
+		7354B0BC2C62945F005297E1 /* ClinicalRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClinicalRecord.swift; sourceTree = "<group>"; };
 		7614D1074DB0BD9144DC75E02B319E09 /* StatisticsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StatisticsTests.swift; path = Tests/StatisticsTests.swift; sourceTree = "<group>"; };
 		775C0010DC236F50A09CDEE5E5B878F4 /* Pods-HealthKitReporter_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-HealthKitReporter_Tests-dummy.m"; sourceTree = "<group>"; };
 		779D0EE7F0734A26C238E0380C189EC2 /* Extensions+HKCategoryValueAppleWalkingSteadinessEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Extensions+HKCategoryValueAppleWalkingSteadinessEvent.swift"; sourceTree = "<group>"; };
@@ -387,6 +393,7 @@
 		3EC752C055E74E43448E3F9267DD1EF5 /* Payload */ = {
 			isa = PBXGroup;
 			children = (
+				7354B0BC2C62945F005297E1 /* ClinicalRecord.swift */,
 				FAF5FC29558E97773504BFB7A6E3F0B7 /* ActivitySummary.swift */,
 				04FBB513B464D9F96552E98FAE1343BF /* Category.swift */,
 				B7389FA911D6AAD9522A038D7CAA3770 /* Characteristic.swift */,
@@ -421,6 +428,7 @@
 		843BE870623805F8E69DF06C55740F7B /* Sample */ = {
 			isa = PBXGroup;
 			children = (
+				7354B0B62C6293B4005297E1 /* ClinicalType.swift */,
 				D95556BAE1B44A602CBAA93EDD3BB464 /* CategoryType.swift */,
 				D17B2FDE0B6D0320BE2EB63FF8E7C28C /* CorrelationType.swift */,
 				DAAC829BB74B370CC624B2BF0FB92560 /* DocumentType.swift */,
@@ -485,6 +493,7 @@
 		D092319D1ED8522122BAC9CBE6A5C206 /* Decorator */ = {
 			isa = PBXGroup;
 			children = (
+				7354B0B82C629433005297E1 /* Extensions+HKClinicalRecord.swift */,
 				725EEB8C2CE54A8A15BDD5F3DB916AB3 /* Extensions+Date.swift */,
 				84F2596E09A7D67E6EDBD73E42B8FFCA /* Extensions+DateComponents.swift */,
 				C36CEC51B9FF98870F6847C451B710FA /* Extensions+Dictionary.swift */,
@@ -836,6 +845,7 @@
 				0A73D80BDF12B704A492BCDC31B6DCE9 /* ActivitySummaryType.swift in Sources */,
 				147CDFDAB74067118EACE3D27B3ABFB4 /* Category.swift in Sources */,
 				2E85B9A398B2D95224290927BADC59E8 /* CategoryType.swift in Sources */,
+				7354B0BD2C62945F005297E1 /* ClinicalRecord.swift in Sources */,
 				B9107578033FD63377AE5FE34612C96C /* Characteristic.swift in Sources */,
 				920D2C33BD40F2FD60637DB22FC1D9E3 /* CharacteristicType.swift in Sources */,
 				200F17D0556D0C72A0A94242E1A07846 /* Correlation.swift in Sources */,
@@ -910,10 +920,12 @@
 				A4DA272CF9C16C647EE397E650C8965E /* Payload.swift in Sources */,
 				4167C4372313D714316FAF687151846C /* PreferredUnit.swift in Sources */,
 				15632A43212028B6971FEEF3F4F60EAB /* Quantity.swift in Sources */,
+				7354B0B72C6293B4005297E1 /* ClinicalType.swift in Sources */,
 				40B4F5AA8240A68BEA9CB07284D179B9 /* QuantityType.swift in Sources */,
 				46A4D70A3EF5E6455C6447E5C66293C1 /* Sample.swift in Sources */,
 				6CEFD04B650EB3390000DF40063C18C2 /* SampleType.swift in Sources */,
 				D6635A98D8EDE329E6F3E52F6617BA47 /* SeriesSampleRetriever.swift in Sources */,
+				7354B0BA2C629433005297E1 /* Extensions+HKClinicalRecord.swift in Sources */,
 				194DCD765C577F4E4B0F785E3794B782 /* SeriesType.swift in Sources */,
 				A7B932E5511DCCF597CDF9EA44742AF2 /* Source.swift in Sources */,
 				C3F370BD24A59AC1833D0ABF52E319FB /* SourceRevision.swift in Sources */,

--- a/Example/Pods/Target Support Files/HealthKitReporter/HealthKitReporter-Info.plist
+++ b/Example/Pods/Target Support Files/HealthKitReporter/HealthKitReporter-Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/HealthKitReporter.podspec
+++ b/HealthKitReporter.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name                  = 'HealthKitReporter'
-  s.version               = '3.0.0'
+  s.version               = '3.1.0'
   s.summary               = 'HealthKitReporter. A wrapper for HealthKit framework.'
   s.swift_versions        = '5.3'
   s.description           = 'Helps to write or read data from Apple Health via HealthKit framework.'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ In addition you can write your own HealthKit objects using <i>Codable</i> wrappe
 
 ### Preparation
 
-At first in your app's entitlements select HealthKit. and in your app's info.plist file add permissions:
+At first in your app's entitlements select HealthKit.
+If you want to read Clinical Records then also check "Clinical Health Records" under Health Kit.
+***NOTE:*** *You can only tick the "Clinical Health Records" checkmark if your development team has a paid Apple developer subscription. To test on a real device, or to publish your application, you will need a paid Apple subscription, but you can still test on the iOS simulator without a subscription by setting the Development Team to None.*
+
+Then in your app's info.plist file add permissions:
 
 ```xml
 <key>NSHealthShareUsageDescription</key>
@@ -27,6 +31,14 @@ If you plan to use **WorkoutRoute** **Series** please provide additionally CoreL
 <key>NSLocationWhenInUseUsageDescription</key>
 <string>WHY_YOU_NEED_TO_SHARE_LOCATION</string>
 ```
+
+If you plan to read **Clinical Records** please provide additionally:
+
+```xml
+<key>NSHealthClinicalHealthRecordsShareUsageDescription</key>
+<string>WHY_YOU_NEED_TO_SHARE_DATA</string>
+```
+
 
 ### Common usage
 
@@ -47,7 +59,7 @@ In examples below every operation is hapenning iside authorization block. It is 
 ### Reading Data
 Create a <i>HealthKitReporter</i> instance.
 
-Authorize deisred types to read, like step count.
+Authorize desired types to read, like step count.
 
 If authorization was successfull (the authorization window was shown) call sample query with type step count to create a **Query** object.
 
@@ -132,9 +144,12 @@ Here is a sample response for steps:
 ```
 
 ### Writing Data
+
+***NOTE:*** *Clinical Records are read only, Health Kit does not allow writing any data to Clinical Records.*
+
 Create a <i>HealthKitReporter</i> instance.
 
-Authorize deisred types to write, like step count.
+Authorize desired types to write, like step count.
 
 You may call manager's <i>preferredUnits(for: )</i> function to pass units (for <b>Quantity Types</b>).
 
@@ -225,7 +240,7 @@ reporter.manager.preferredUnits(for: [.stepCount]) { (dictionary, error) in
 
 Create a <i>HealthKitReporter</i> instance.
 
-Authorize deisred types to read/write, like step count and sleep analysis.
+Authorize desired types to read/write, like step count and sleep analysis.
 
 You might create an App which will be called every time by HealthKit, and receive notifications, that some data was changed in HealthKit depending on frequency. But keep in mind that sometimes the desired frequency you set cannot be fulfilled by HealthKit.
 
@@ -305,7 +320,7 @@ pod 'HealthKitReporter'
 or 
 
 ```ruby
-pod 'HealthKitReporter', '~> 3.0.0'
+pod 'HealthKitReporter', '~> 3.1.0'
 ```
 
 ### Swift Package Manager
@@ -315,7 +330,7 @@ To install it, simply add the following lines to your Package.swift file
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/VictorKachalov/HealthKitReporter.git", from: "3.0.0")
+    .package(url: "https://github.com/VictorKachalov/HealthKitReporter.git", from: "3.1.0")
 ]
 ```
 
@@ -324,7 +339,7 @@ dependencies: [
 Add the line in your cartfile 
 
 ```ruby
-github "VictorKachalov/HealthKitReporter" "3.0.0"
+github "VictorKachalov/HealthKitReporter" "3.1.0"
 ```
 
 ## Author

--- a/Sources/Decorator/Extensions+HKClinicalRecord.swift
+++ b/Sources/Decorator/Extensions+HKClinicalRecord.swift
@@ -1,0 +1,36 @@
+//
+//  Extensions+HKClinicalRecord.swift
+//  HealthKitReporter
+//
+//  Created by Quentin on 01.08.24.
+//
+
+import HealthKit
+
+@available(iOS 12.0, *)
+extension HKClinicalRecord: Harmonizable {
+    typealias Harmonized = ClinicalRecord.Harmonized
+    
+    func harmonize() throws -> Harmonized {
+        let fhirVersion: String? = if #available(iOS 14.0, *) {
+            fhirResource?.fhirVersion.stringRepresentation
+        } else {
+            nil
+        }
+        var fhirData: String? {
+            guard let data: Data = fhirResource?.data,
+                  let jsonString = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+            return jsonString
+        }
+        
+        return Harmonized(
+            displayName: displayName,
+            fhirSourceUrl: fhirResource?.sourceURL?.absoluteString,
+            fhirVersion: fhirVersion,
+            fhirData: fhirData,
+            metadata: metadata?.asMetadata
+        )
+    }
+}

--- a/Sources/Decorator/Extensions+HKSample.swift
+++ b/Sources/Decorator/Extensions+HKSample.swift
@@ -26,6 +26,11 @@ extension HKSample {
                 return try Electrocardiogram(electrocardiogram: electrocardiogram, voltageMeasurements: [])
             }
         }
+        if #available(iOS 12.0, *) {
+            if let clinicalRecord = self as? HKClinicalRecord {
+                return try ClinicalRecord(clinicalRecord: clinicalRecord)
+            }
+        }
         throw HealthKitError.parsingFailed("HKSample could not be parsed")
     }
 }

--- a/Sources/Decorator/Extensions+String.swift
+++ b/Sources/Decorator/Extensions+String.swift
@@ -47,6 +47,11 @@ public extension String {
                 return type
             }
         }
+        if #available(iOS 12.0, *) {
+            if let type = try? ClinicalType.make(from: self) {
+                return type
+            }
+        }
         return nil
     }
 

--- a/Sources/Model/Payload/ClinicalRecord.swift
+++ b/Sources/Model/Payload/ClinicalRecord.swift
@@ -1,0 +1,199 @@
+//
+//  ClinicalRecord.swift
+//  HealthKitReporter
+//
+//  Created by Quentin on 01.08.24.
+//
+
+import HealthKit
+
+@available(iOS 12.0, *)
+public struct ClinicalRecord: Identifiable, Sample {
+    public struct Harmonized: Codable {
+        public let displayName: String
+        public let fhirSourceUrl: String?
+        public let fhirVersion: String?
+        public let fhirData: String?
+        public let metadata: Metadata?
+        
+        public init(
+            displayName: String,
+            fhirSourceUrl: String?,
+            fhirVersion: String?,
+            fhirData: String?,
+            metadata: Metadata?
+        ) {
+            self.displayName = displayName
+            self.fhirSourceUrl = fhirSourceUrl
+            self.fhirVersion = fhirVersion
+            self.fhirData = fhirData
+            self.metadata = metadata
+        }
+        
+        public func copyWith(
+            displayName: String? = nil,
+            fhirSourceUrl: String? = nil,
+            fhirVersion: String? = nil,
+            fhirData: String? = nil,
+            metadata: Metadata? = nil
+        ) -> Harmonized {
+            return Harmonized(
+                displayName: displayName ?? self.displayName,
+                fhirSourceUrl: fhirSourceUrl ?? self.fhirSourceUrl,
+                fhirVersion: fhirVersion ?? self.fhirVersion,
+                fhirData: fhirData ?? self.fhirData,
+                metadata: metadata ?? self.metadata
+            )
+        }
+    }
+    
+    public let uuid: String
+    public let identifier: String
+    public let startTimestamp: Double
+    public let endTimestamp: Double
+    public let device: Device?
+    public let sourceRevision: SourceRevision
+    public let harmonized: Harmonized
+    
+    init(clinicalRecord: HKClinicalRecord) throws {
+        let fhirVersion: String? = if #available(iOS 14.0, *) {
+            clinicalRecord.fhirResource?.fhirVersion.stringRepresentation
+        } else {
+            nil
+        }
+        var fhirData: String? {
+            guard let data: Data = clinicalRecord.fhirResource?.data,
+                  let jsonString = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+            return jsonString
+        }
+        
+        self.uuid = clinicalRecord.uuid.uuidString
+        self.identifier = clinicalRecord.clinicalType.identifier
+        self.startTimestamp = clinicalRecord.startDate.timeIntervalSince1970
+        self.endTimestamp = clinicalRecord.endDate.timeIntervalSince1970
+        self.device = Device(device: clinicalRecord.device)
+        self.sourceRevision = SourceRevision(sourceRevision: clinicalRecord.sourceRevision)
+        self.harmonized = Harmonized(
+            displayName: clinicalRecord.displayName,
+            fhirSourceUrl: clinicalRecord.fhirResource?.sourceURL?.absoluteString,
+            fhirVersion: fhirVersion,
+            fhirData: fhirData,
+            metadata: clinicalRecord.metadata?.asMetadata
+        )
+    }
+    
+    public init(
+        identifier: String,
+        startTimestamp: Double,
+        endTimestamp: Double,
+        device: Device?,
+        sourceRevision: SourceRevision,
+        harmonized: Harmonized
+    ) {
+        self.uuid = UUID().uuidString
+        self.identifier = identifier
+        self.startTimestamp = startTimestamp
+        self.endTimestamp = endTimestamp
+        self.device = device
+        self.sourceRevision = sourceRevision
+        self.harmonized = harmonized
+    }
+    
+    public func copyWith(
+        identifier: String? = nil,
+        startTimestamp: Double? = nil,
+        endTimestamp: Double? = nil,
+        device: Device? = nil,
+        sourceRevision: SourceRevision? = nil,
+        harmonized: Harmonized? = nil
+    ) -> ClinicalRecord {
+        return ClinicalRecord(
+            identifier: identifier ?? self.identifier,
+            startTimestamp: startTimestamp ?? self.startTimestamp,
+            endTimestamp: endTimestamp ?? self.endTimestamp,
+            device: device ?? self.device,
+            sourceRevision: sourceRevision ?? self.sourceRevision,
+            harmonized: harmonized ?? self.harmonized
+        )
+    }
+}
+// MARK: - Payload
+@available(iOS 12.0, *)
+extension ClinicalRecord: Payload {
+    public static func make(from dictionary: [String: Any]) throws -> ClinicalRecord {
+        guard
+            let identifier = dictionary["identifier"] as? String,
+            let startTimestamp = dictionary["startTimestamp"] as? NSNumber,
+            let endTimestamp = dictionary["endTimestamp"] as? NSNumber,
+            let sourceRevision = dictionary["sourceRevision"] as? [String: Any],
+            let harmonized = dictionary["harmonized"] as? [String: Any]
+        else {
+            throw HealthKitError.invalidValue("Invalid dictionary: \(dictionary)")
+        }
+        let device = dictionary["device"] as? [String: Any]
+        return ClinicalRecord(
+            identifier: identifier,
+            startTimestamp: Double(truncating: startTimestamp),
+            endTimestamp: Double(truncating: endTimestamp),
+            device: device != nil
+            ? try Device.make(from: device!)
+            : nil,
+            sourceRevision: try SourceRevision.make(from: sourceRevision),
+            harmonized: try Harmonized.make(from: harmonized)
+        )
+    }
+    public static func collect(from array: [Any]) throws -> [ClinicalRecord] {
+        var results = [ClinicalRecord]()
+        for element in array {
+            if let dictionary = element as? [String: Any] {
+                let harmonized = try ClinicalRecord.make(from: dictionary)
+                results.append(harmonized)
+            }
+        }
+        return results
+    }
+}
+// MARK: - Factory
+@available(iOS 12.0, *)
+extension ClinicalRecord {
+    public static func collect(results: [HKSample]) -> [ClinicalRecord] {
+        var samples = [ClinicalRecord]()
+        if let clinicalRecords = results as? [HKClinicalRecord] {
+            for clinicalRecord in clinicalRecords {
+                do {
+                    let sample = try ClinicalRecord(
+                        clinicalRecord: clinicalRecord
+                    )
+                    samples.append(sample)
+                } catch {
+                    continue
+                }
+            }
+        }
+        return samples
+    }
+}
+// MARK: - Payload
+@available(iOS 12.0, *)
+extension ClinicalRecord.Harmonized: Payload {
+    public static func make(from dictionary: [String: Any]) throws -> ClinicalRecord.Harmonized {
+        guard
+            let displayName = dictionary["displayName"] as? String,
+            let fhirSourceUrl = dictionary["fhirSourceUrl"] as? String?,
+            let fhirVersion = dictionary["fhirVersion"] as? String?,
+            let fhirData = dictionary["fhirData"] as? String?
+        else {
+            throw HealthKitError.invalidValue("Invalid dictionary: \(dictionary)")
+        }
+        let metadata = dictionary["metadata"] as? [String: Any]
+        return ClinicalRecord.Harmonized(
+            displayName: displayName,
+            fhirSourceUrl: fhirSourceUrl,
+            fhirVersion: fhirVersion,
+            fhirData: fhirData,
+            metadata: metadata?.asMetadata
+        )
+    }
+}

--- a/Sources/Model/Type/Sample/ClinicalType.swift
+++ b/Sources/Model/Type/Sample/ClinicalType.swift
@@ -1,0 +1,44 @@
+//
+//  SampleType.swift
+//  HealthKitReporter
+//
+//  Created by Quentin on 01.08.24.
+//
+
+import HealthKit
+
+public enum ClinicalType: Int, CaseIterable, SampleType {
+    case allergyRecord
+    case conditionRecord
+    case immunizationRecord
+    case labResultRecord
+    case medicationRecord
+    case procedureRecord
+    case vitalSignRecord
+    
+    public var identifier: String? {
+        return original?.identifier
+    }
+    
+    public var original: HKObjectType? {
+        if #available(iOS 12.0, *) {
+            switch self {
+            case .allergyRecord:
+                return HKObjectType.clinicalType(forIdentifier: .allergyRecord)
+            case .conditionRecord:
+                return HKObjectType.clinicalType(forIdentifier: .conditionRecord)
+            case .immunizationRecord:
+                return HKObjectType.clinicalType(forIdentifier: .immunizationRecord)
+            case .labResultRecord:
+                return HKObjectType.clinicalType(forIdentifier: .labResultRecord)
+            case .medicationRecord:
+                return HKObjectType.clinicalType(forIdentifier: .medicationRecord)
+            case .procedureRecord:
+                return HKObjectType.clinicalType(forIdentifier: .procedureRecord)
+            case .vitalSignRecord:
+                return HKObjectType.clinicalType(forIdentifier: .vitalSignRecord)
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Status
READY

## Migrations
NO

## Description
Added support for HKClinicalRecord.

## Steps to Test or Reproduce
I'm not familiar with swift so I did not add the new feature to the Example, and I tested via the flutter implementation instead.

## Impacted Areas in Application
It will now be possible to request permissions to read Clinical Records (as any other permission), and to query Clinical Records (as any other sample).
